### PR TITLE
Increase contrast between s:select & s:background:

### DIFF
--- a/colors/hybrid_material.vim
+++ b/colors/hybrid_material.vim
@@ -85,7 +85,7 @@ if has("gui_running") || ($NVIM_TUI_ENABLE_TRUE_COLOR && has("nvim"))
   let s:vmode      = "gui"
   let s:background = "#263238"
   let s:foreground = "#c5c8c6"
-  let s:selection  = "#37474F"
+  let s:selection  = "#455A64"
   let s:line       = "#212D32"
   let s:comment    = "#707880"
   let s:red        = "#cc6666"


### PR DESCRIPTION
- As referenced in [Issue #4](https://github.com/kristijanhusak/vim-hybrid-material/issues/4)
- Shifting `s:select` from Blue Grey 800 to Blue Grey 700 creates an
  increase in constrast between the `LineNr` `fg` and the `Visual` bg. Using
  Blue Grey 800, the contrast is subtle as to be easily missed (which
  especially makes
  line numbers hard to read)
- This change only affects gvim colours

## Demo of changes (reference: line number)

Before:
![image](https://cloud.githubusercontent.com/assets/1713932/9011997/6e651d24-37a9-11e5-9f8c-41d614fe9657.png)

After:
![image](https://cloud.githubusercontent.com/assets/1713932/9012000/73e4b890-37a9-11e5-8d2b-1d7b7ada0f0e.png)
