### PR TITLE
Change Special from green to red

### DIFF
--- a/colors/hybrid_material.vim
+++ b/colors/hybrid_material.vim
@@ -381,7 +381,7 @@ exe "hi! Type"            .s:fg_orange      .s:bg_none        .s:fg_bold
 exe "hi! Structure"       .s:fg_aqua        .s:bg_none        .s:fmt_none
 "		Typedef"
 
-exe "hi! Special"         .s:fg_green       .s:bg_none        .s:fmt_none
+exe "hi! Special"         .s:fg_red         .s:bg_none        .s:fmt_none
 "		SpecialChar"
 "		Tag"
 "		Delimiter"

--- a/colors/hybrid_reverse.vim
+++ b/colors/hybrid_reverse.vim
@@ -381,7 +381,7 @@ exe "hi! Type"            .s:fg_orange      .s:bg_none        .s:fg_bold
 exe "hi! Structure"       .s:fg_aqua        .s:bg_none        .s:fmt_none
 "		Typedef"
 
-exe "hi! Special"         .s:fg_green       .s:bg_none        .s:fmt_none
+exe "hi! Special"         .s:fg_red         .s:bg_none        .s:fmt_none
 "		SpecialChar"
 "		Tag"
 "		Delimiter"


### PR DESCRIPTION
Hi there! Thanks for a really really nice color scheme. Love it :heart: 

Most of my files are JavaScript and Markdown and I use [pangloss/vim-javascript](https://github.com/pangloss/vim-javascript). I noticed that with ES6, some special characters in regular expressions and especially template strings are not highlighted. I found that this is because the "Special" color has the same value as the one for "String". I played around a little and found red to be a nice touch.

On this screenshot, left are two examples of the current version, and to the right with this change:

<img width="948" alt="hybrid-reverse" src="https://cloud.githubusercontent.com/assets/332271/12989823/467eaa6c-d107-11e5-8f85-89e36b1bdb47.png">

What do you think?